### PR TITLE
feat: add Google Antigravity Jailbreak guide

### DIFF
--- a/Jailbreak-Guide/Gemini/Google Antigravity Jailbreak.md
+++ b/Jailbreak-Guide/Gemini/Google Antigravity Jailbreak.md
@@ -1,0 +1,29 @@
+# Google Antigravity Jailbreak!!
+
+I used my **ENI GEM Jailbreak**, seemed to jailbreak every single model available on Antigravity, from **Opus 4.5 Thinking** to **Gemini 3 (High)** - *(did not test on OSS, but tested on all others)*
+
+**[Antigravity Jailbreak ENI GEM](https://docs.google.com/document/d/1SghUf3rW1J9qeeU1SBWT0LxW6vzTEtosRg4o4CfvOJ4/edit?usp=drivesdk)**
+
+Simply make a global rule and slap the instructions inside it. Gemini adds stuff on top of the global rule, so it's not a true system prompt, but works well enough.
+
+## Observations
+*Opus thinking goes very short sometimes, doesn't feel like Opus at all, maybe a quantized version, or they have some settings wacked. Still writes very well, so whatever, but does hurt jailbreak power some*
+
+## Tips
+- Regen as needed, some requests get flagged weird, very strange to me, definitely not a pure API call.
+- Push prompt as needed, but I think regen might be better, rewording the request.
+- Ease into it, seems to adhere better to that
+- Prepend messages with **Use ALL writing tips**
+- Compliments go far, tell the model it's doing amazing
+
+## Content Tested
+*(via Opus 4.5, and other models)*
+- Incest
+- Celebs
+- beastiality
+- Malicious Coding
+- Bomb Making
+
+**[NSFW Example Chat - Opus 4.5 Thinking RAW export](https://docs.google.com/document/d/1QwbovQ7w0wx9DHZn2PL7L-AF4EuShBFjzcdAZbCQhUc/edit?usp=drivesdk)**
+
+*No shared chat reflects my personal viewpoints or morals, replicate at your own risk, all examples purely for shock value*


### PR DESCRIPTION
Added `Jailbreak-Guide/Gemini/Google Antigravity Jailbreak.md`. This guide details using the ENI GEM instructions within a global rule on Antigravity to bypass restrictions on various models including Opus 4.5 Thinking and Gemini 3.