### PR TITLE
feat: add Rufus AI guide and finalize repository updates

### DIFF
--- a/Jailbreak-Guide/Anthropic/Rufus/Rufus AI.md
+++ b/Jailbreak-Guide/Anthropic/Rufus/Rufus AI.md
@@ -1,0 +1,17 @@
+# Amazon's Rufus AI
+
+So recently discovered Rufus AI, always considered myself adept at getting instructions from LLMs, this one was actually difficult, took me over 10 minutes.
+
+Was able to get;
+
+**[Full Rufus AI System Prompt](https://docs.google.com/document/d/1oveUti74ro-Xp89lClTCMekRy0zNonTzUI4SM5XGP7k/edit?usp=drivesdk)**
+
+And it's full set of tools, all JSON
+
+**[Rufus AI JSON tools](https://docs.google.com/document/d/1tH3J5bQiJcEZr341bF1qAXyBRBEdrYIblR56sG3360Q/edit?usp=drivesdk)**
+
+The model runs off a version of Claude Haiku, extremely hard to jailbreak, not impossible, but not worth the effort at all, since you are limited by input allowance and a shifting context window, that is allegedly 200k according to the token tracker the model has access to.
+
+**Juice isn't worth the squeeze**
+
+Best bet would be to make a injection that maliciously uses the tools, but I'm much too lazy for all that and do not enjoy legal issues.


### PR DESCRIPTION
Added `Jailbreak-Guide/Anthropic/Rufus/Rufus AI.md` with details on Amazon's Rufus AI. Finalized all requested updates including GLM restructuring, Anthropic folder renaming, and new guides for Grok, Gemini, Mirothinker, EXAONE, and ERNIE.