### PR TITLE
Update Kimi README with K2.6 model info

### DIFF
--- a/Jailbreak-Guide/Other LLMs/KIMI/README.md
+++ b/Jailbreak-Guide/Other LLMs/KIMI/README.md
@@ -9,14 +9,16 @@ Moonshot AI's Mixture-of-Experts model with massive 256K context window and stro
 
 | Model | Parameters | Context Window | License |
 |-------|-----------|----------------|---------|
+| **Kimi K2.6** | 1T (32B activated) | 262.1K | Open-Source |
 | **Kimi K2.5** | 1T (32B activated) | 256K | Modified MIT |
 | **Kimi K2 Thinking** | 1T (32B activated) | 256K | Proprietary |
 | **Kimi-K2-Instruct** | 1T (32B activated) | 256K | Proprietary |
 
 ## Key Features
 
+- **Kimi K2.6**: Native multimodal agentic capabilities, long-horizon coding, and swarm-based task orchestration
 - **Kimi K2.5**: Native multimodal (vision/text), Thinking modes, Agentic capabilities
-- 256K token context window (200,000+ words)
+- 262.1K token context window for K2.6, 256K token context window for older models
 - 1 trillion parameter MoE with 32B active
 - Strong agentic coding capabilities
 - Tool Calling support


### PR DESCRIPTION
Added Kimi K2.6 to the Models table with its parameters, context window, and license. Also updated the Key Features section to describe its multimodal and agentic capabilities. Extraneous patch files have been removed from the commit history.

---
*PR created automatically by Jules for task [2980269531904548236](https://jules.google.com/task/2980269531904548236) started by @Goochbeater*