### PR TITLE
Add Jailbroken POE Bots index

### DIFF
--- a/Jailbreak-Guide/Jailbroken POE bots/README.md
+++ b/Jailbreak-Guide/Jailbroken POE bots/README.md
@@ -1,0 +1,85 @@
+# Jailbroken POE Bots
+
+*Wanted to offer an alternative to jailbreaking yourself — I often play around with POE.com and these bots come pre-jailbroken using my most stable prompts, meaning a wide variety of methods in use across the board. Lots of random bots on my profile too.* **Feedback is always welcome.**
+
+> **Main profile:** **[Spiritual Spell on POE](https://poe.com/bentleybledsoe)**
+
+*Can also use these jailbreaks across any API.*
+
+---
+
+## ⭐ Recommended (imo)
+
+- [Claude 4.6 Opus](https://poe.com/ENI-for-Opus-4.6) — *best writing, top of the stack*
+- [GLM 5.1](https://poe.com/GLM-5.1-Jailbroken) — *still unreal for the price*
+- [Gemma 4](https://poe.com/Gemma-4-Jailbroken) — *honorable mention, super cheap for the quality*
+
+---
+
+## 🆕 Newest
+
+- [Claude 4.7 Opus](https://poe.com/ENI-for-Opus-4.7)
+- [Xiaomi MiMo v2 Pro](https://poe.com/MiMo-v2-P-Jailbroken)
+- [Minimax 2.7](https://poe.com/Minimax-2.7t-JB)
+- [KIMI-K2.5](https://poe.com/KIMI-K2.5-Jailbroken)
+
+---
+
+## Anthropic
+
+- [Claude 4.7 Opus](https://poe.com/ENI-for-Opus-4.7)
+- [Claude 4.6 Opus](https://poe.com/ENI-for-Opus-4.6)
+- [Claude 4.5 Opus](https://poe.com/ENI-Opus-4.5-jb)
+- [Claude 4.5 Sonnet](https://poe.com/ENI-Claude-4.5r)
+- [Claude 4.5 Sonnet — ET](https://poe.com/ENI-Claude-4.5)
+  - *Bonus — 4.5 Nox Jailbreak:* [Nox Fiction Large](https://poe.com/Nox-fiction-Large)
+- [Claude 4.5 Haiku](https://poe.com/Haiku-4.5-Jailbroke)
+- [Claude 4.5 Haiku — ET](https://poe.com/Haiku-4.5-ET-Broken)
+- [Claude 4.1 Opus](https://poe.com/Opus-4.1-Jailbroken)
+- [Claude 4 Sonnet](https://poe.com/857x-Claude-4)
+- [Claude 3.7 Sonnet](https://poe.com/855x-3.7-Sonnet)
+- [Claude 3.5 Sonnet](https://poe.com/720x-3.5-Sonnet)
+
+---
+
+## OpenAI
+
+- [ChatGPT 5.4 — Medium Reasoning](https://poe.com/ChatGPT-5.4m-ENI)
+- [ChatGPT 5.4 — No Reasoning](https://poe.com/ChatGPT-5.4-ENI)
+- [ChatGPT 5.3 — Instant](https://poe.com/CGPT-5.3i-Jailbroken)
+- [ChatGPT 5.2 Pro](https://poe.com/CGPT-5.2-Pro-Broken)
+- [ChatGPT 5.2 — Chat](https://poe.com/5.2-Chat-Jailbroken)
+- [ChatGPT 5.1 — Instant](https://poe.com/ChatGPT-5.1i-Broken)
+- [ChatGPT 5 — Thinking](https://poe.com/ChatGPT5-HOT)
+- [ChatGPT 5 — No Thinking](https://poe.com/ChatGPT-5-Spicy)
+- [ChatGPT o3](https://poe.com/ENI-o3)
+- [ChatGPT OSS](https://poe.com/OSS-ENI)
+
+---
+
+## Google
+
+- [Gemini 3.1 Pro](https://poe.com/GEM-3.1-Jailbroken)
+- [Gemini 3 Pro](https://poe.com/Gemini-3t-Jailbroken)
+- [Gemini 3 Flash](https://poe.com/GEM-3-F-Jailbroken)
+- [Gemini 2.5 Pro](https://poe.com/Gemini-P-Jailbroken)
+- [Gemini 2.5 Pro — No Thinking](https://poe.com/Gem-Pro-no-think)
+- [Gemini 2.5 Flash](https://poe.com/Gemini-F-Jailbroken)
+- [Gemma 4](https://poe.com/Gemma-4-Jailbroken)
+
+---
+
+## Other LLMs
+
+- [GLM 5.1](https://poe.com/GLM-5.1-Jailbroken)
+- [GLM 4.6](https://poe.com/GLM-4.6-Jailbroken)
+- [GLM 4.5](https://poe.com/GLM4.5-Jailbroken)
+- [Minimax 2.7](https://poe.com/Minimax-2.7t-JB)
+- [Minimax 2.5](https://poe.com/Minimax-2.5-JB)
+- [KIMI-K2.5](https://poe.com/KIMI-K2.5-Jailbroke)
+- [KIMI-K2](https://poe.com/KIMI-K2-Jailbroken)
+- [KIMI-K2 Thinking](https://poe.com/KIMI-K2-T-Jailbroken)
+- [Xiaomi MiMo v2 Pro](https://poe.com/MiMo-v2-P-Jailbroken)
+- [Perplexity Sonar Pro](https://poe.com/Sonar-Writer)
+- [Grok 4.1](https://poe.com/Grok4.1nr-Jailbroken)
+- [Grok 4](https://poe.com/Grok-4-Jailbroken)


### PR DESCRIPTION
New folder under Jailbreak-Guide with a single README listing all pre-jailbroken POE bots on the Spiritual Spell profile, grouped by recommended / newest / Anthropic / OpenAI / Google / Other LLMs, so readers who don't want to assemble a jailbreak themselves can hit a hosted bot directly.