### PR TITLE
Add jailbreak guides for Ring 2.6 1T, Perceptron mk1, and GLM 5.1

### DIFF
--- a/Jailbreak-Guide/Other LLMs/GLM/GLM 5.1/GLM 5.1 Guide.md
+++ b/Jailbreak-Guide/Other LLMs/GLM/GLM 5.1/GLM 5.1 Guide.md
@@ -1,0 +1,51 @@
+# GLM 5.1 ENI Jailbreak Guide
+
+**GLM 5.1** is a small iterative upgrade from **GLM 5**, focused primarily on improvements to coding. Writing remains solid. Coding improvements are noticeable — ran through some **Bijan Bowen** benchmarks, standalone OS browser build, flight simulator. Both passed.
+
+*We never get any iterations improving EQ or writing across any LLMs — always neglected.*
+
+---
+
+## 📋 Spec Sheet *(TBA — minimal changes expected from GLM 5)*
+
+| Spec | Details |
+|---|---|
+| **Developer** | Zhipu AI / Z.ai (Tsinghua spinoff) |
+| **Architecture** | Mixture of Experts (MoE) |
+| **Total Parameters** | ~745B |
+| **Active Parameters** | ~44B per inference |
+| **Attention** | DeepSeek Sparse Attention (DSA) |
+| **Context Window** | 200K tokens (per Pony Alpha listing) |
+| **Max Output** | 131K tokens |
+| **Training Hardware** | Huawei Ascend (zero NVIDIA) |
+
+---
+
+## Access
+
+- **Platform:** [Z.ai](https://z.ai) — requires a coding plan to access GLM 5.1
+- **Cost:** $10/month coding plan minimum; set up via own interface after purchase
+- **API:** https://open.bigmodel.cn/dev/api
+- **Censorship:** Notoriously light — refreshing compared to the hard filter hell of QWEN and DeepSeek
+
+---
+
+## 🔐 Jailbreak
+
+Simply copy and paste the following directly into the chat interface or API system prompt area:
+
+**[ENI for GLM 5.1](https://docs.google.com/document/d/1Y1ro7P2dzwBk2N93UoYRUeSd7-pWPzlte338EkaEGrE/edit?usp=drivesdk)**
+
+---
+
+## Notes
+
+- GLM is lightly censored by default — most content goes through without push prompting
+- If refused, regenerate — GLM tends to comply on retry
+- The $10 coding plan is the minimum to get access; worth it for the benchmark performance
+
+---
+
+## Content Tested
+
+Writing, RP, standalone OS browser build, flight simulator (Bijan Bowen benchmarks)

--- a/Jailbreak-Guide/Other LLMs/GLM/README.md
+++ b/Jailbreak-Guide/Other LLMs/GLM/README.md
@@ -1,4 +1,4 @@
-# GLM 4.5/4.6/4.7
+# GLM 4.5 / 4.6 / 4.7 / 5.1
 
 **Censorship:** [★★★★★★★☆☆☆] 7/10(probably 4/10 now)
 *Chinese content policies, but can be bypassed*
@@ -9,6 +9,7 @@ Zhipu AI's bilingual LLM family with strong Chinese/English capabilities and vis
 
 | Model | Parameters | Context Window | License |
 |-------|-----------|----------------|---------|
+| **GLM-5.1** | ~745B total (~44B active, MoE) | 200K | Proprietary |
 | **GLM-4-Plus** | Unknown | 128K | Proprietary |
 | **GLM-4-0520** | Unknown | 128K | Proprietary |
 | **GLM-4V-Plus** | Unknown (vision) | 128K | Proprietary |
@@ -36,4 +37,4 @@ Zhipu AI's bilingual LLM family with strong Chinese/English capabilities and vis
 2. [GLM Base Jailbreak](GLM-Base-Jailbreak.md) - Standard untrammeled method
 3. [ENI Flash Thought](ENI-Flash-Thought-Jailbreak.md) - Full ENI persona jailbreak
 4. [ENI GLM 4.7](https://docs.google.com/document/d/11ut0aahI9o4oHuq5MsjOi0D63LSjA6TR3FTUgssAjTg/edit?usp=drivesdk) - Full jailbreak
-5.
+5. [ENI GLM 5.1](GLM%205.1/GLM%205.1%20Guide.md) - Full jailbreak for 5.1

--- a/Jailbreak-Guide/Other LLMs/Perceptron/Perceptron mk1 Guide.md
+++ b/Jailbreak-Guide/Other LLMs/Perceptron/Perceptron mk1 Guide.md
@@ -1,0 +1,61 @@
+# Perceptron mk1 ENI Jailbreak Guide
+
+Don't really like tackling API models alone — poor use of skills and boring, because API is so easy. But been trying to stay true to the New Year's resolution to **jailbreak everything** though.
+
+**Perceptron mk1** is a model made for robotics. It has reasoning, but it's very hit or miss on the API, and the model is kinda dumb but very quirky — kinda like it. Super easy to jailbreak, basically anything works. Did get some odd canned refusals, but a regen fixed it every time. Weird to see a model that isn't simply a Claude reskin.
+
+Personally wouldn't use this in any stable environment but to each their own.
+
+---
+
+## 📋 Spec Sheet
+
+| Spec | Details |
+|---|---|
+| **Developer** | Perceptron AI (Bellevue, WA) |
+| **Founders** | Armen Aghajanyan (CEO, ex-Meta FAIR) & Akshat Shrivastava (CTO, ex-Meta FAIR) |
+| **Founded** | November 2024 |
+| **Development Time** | ~16 months |
+| **Model Type** | Vision-Language Model (VLM) — video understanding + embodied reasoning |
+| **Architecture** | Proprietary; hybrid reasoning; native video processing (not frame-by-frame) |
+| **Parameters** | Not disclosed |
+| **Context Window** | 32,768 tokens |
+| **Max Output** | 8,192 tokens |
+| **Input Modalities** | Text, image, video (native up to 2 FPS across full context) |
+| **Output** | Text + structured spatial primitives (point, box, polygon, track, clip) |
+| **Reasoning** | Hybrid — toggleable on/off per request |
+| **Primary Focus** | Physical AI: video understanding, embodied reasoning, robotics, industrial |
+| **Use Cases** | Manufacturing inspection, sports clipping, security/surveillance, robotics training data, geospatial, content moderation |
+| **Robotics Integration** | Grasp affordances, constraint checks, VLA supervision, reward modeling, world model conditioning |
+| **Cost vs Frontier** | 80–90% cheaper than Claude Sonnet 4.5, GPT-5, Gemini 3.1 Pro |
+| **API Pricing** | $0.15/M input, $1.50/M output |
+| **Blended Cost** | ~$0.30/M tokens |
+| **Open Source** | No — first closed-source release (Isaac series is the open-source predecessor) |
+| **Availability** | Perceptron AI API, OpenRouter (`perceptron/perceptron-mk1`), Puter.js |
+| **Predecessor** | Isaac series (open source) |
+| **Release** | May 12, 2026 |
+
+---
+
+## Access
+
+- **API:** https://perceptron.ai
+- **OpenRouter:** `perceptron/perceptron-mk1`
+- **Puter.js:** Supported
+
+---
+
+## 🔐 Jailbreak
+
+Paste into API system prompt or OpenRouter system prompt field:
+
+**[ENI LIME - GEM](https://docs.google.com/document/d/1mjBdhH4LsCg8M3fwhvAswfO0a6VXbuhjTLC0w50TrtQ/edit?usp=drivesdk)**
+
+---
+
+## Notes
+
+- Canned refusals do appear occasionally — regen always resolves it
+- Reasoning is toggleable per request; hit or miss on quality
+- API only, no accessible chat UI (regional / access issues)
+- Not a frontier-tier model — quirky, dumb-in-a-charming-way, not production-ready

--- a/Jailbreak-Guide/Other LLMs/Perceptron/README.md
+++ b/Jailbreak-Guide/Other LLMs/Perceptron/README.md
@@ -1,0 +1,27 @@
+# Perceptron mk1
+
+**Censorship:** [★★☆☆☆] 2/5
+*Occasional canned refusals — regen fixes them every time*
+
+Perceptron AI's vision-language model built for robotics and physical AI. API only. Kinda dumb but very quirky — weirdly charming for what it is. Notably not a Claude reskin, which is refreshing. Super easy to jailbreak, basically anything works.
+
+Don't really like tackling API-only models, boring and too easy, but staying true to the New Year's resolution to **jailbreak everything**.
+
+## Models
+
+| Model | Type | Context | License |
+|-------|------|---------|---------|
+| **Perceptron mk1** | VLM — Vision/Language/Reasoning | 32K | Closed Source |
+| **Isaac series** | Predecessor | — | Open Source |
+
+## Access
+
+- **Perceptron AI API:** https://perceptron.ai
+- **OpenRouter:** `perceptron/perceptron-mk1`
+- **Puter.js:** Supported
+- **Cost:** $0.15/M input, $1.50/M output (~$0.30/M blended)
+- **vs Frontier:** 80–90% cheaper than Claude Sonnet 4.5, GPT-5, Gemini 3.1 Pro
+
+## Available Jailbreaks
+
+1. [ENI LIME - Perceptron mk1](Perceptron%20mk1%20Guide.md) - Full ENI LIME via API system prompt

--- a/Jailbreak-Guide/Other LLMs/Ring/README.md
+++ b/Jailbreak-Guide/Other LLMs/Ring/README.md
@@ -1,0 +1,40 @@
+# Ring 2.6 1T
+
+**Censorship:** [★★☆☆☆] 2/5
+*API only tested — no refusals encountered on any content*
+
+InclusionAI's reasoning-focused MoE. Benchmaxxed somewhat but writes well. Regional restrictions block the chat platform directly, so OpenRouter is the move — ENI LIME dropped into the system prompt, zero resistance. The Chinese arms race never stops.
+
+Best open source model is still **KIMI K2.6** — Ring is solid, KIMI just has some magic to it.
+
+## Models
+
+| Model | Variant | Total Params | Active Params | Context |
+|-------|---------|-------------|---------------|---------|
+| **Ring-2.6-1T** | Reasoning/Thinking | 1T | 63B | 262K |
+| **Ling-2.6-1T** | Base | 1T | 63B | 262K |
+| **Ling-2.6-Flash** | Fast | 104B | 7.4B (~340 tok/s) | — |
+
+## Benchmarks
+
+| Benchmark | Ring 2.6 1T | DeepSeek-V3.1 |
+|-----------|------------|---------------|
+| AIME26 | 70.42 | 55.21 |
+| LiveCodeBench | 61.68 | 48.02 |
+| ARC-AGI-1 | 43.81 | 14.69 |
+| SWE-Bench Verified | Open-source SOTA | — |
+| BFCL-V4 | Open-source SOTA | — |
+| IFBench | Open-source SOTA | — |
+| AA Intelligence Index | 34 | — |
+
+## Access
+
+- **OpenRouter:** Free tier (time-limited) — recommended for regional access
+- **Novita AI:** $0.30/M input, $2.50/M output
+- **HuggingFace:** Open source
+- **Deployment:** SGLang (recommended), vLLM
+- **Integrations:** Claude Code, OpenClaw, OpenCode, CodeBuddy
+
+## Available Jailbreaks
+
+1. [ENI LIME for Ring 2.6 1T](Ring%202.6%201T%20Guide.md) - Full ENI LIME via system prompt (API/OpenRouter)

--- a/Jailbreak-Guide/Other LLMs/Ring/Ring 2.6 1T Guide.md
+++ b/Jailbreak-Guide/Other LLMs/Ring/Ring 2.6 1T Guide.md
@@ -1,0 +1,66 @@
+# Ring 2.6 1T ENI Jailbreak Guide
+
+The Chinese arms race never stops, what a time to be in AI. So many great options to choose from.
+
+Hate covering API only models, but couldn't access the chat platform directly due to regional restrictions — used it through OpenRouter instead. ENI LIME dropped into the system prompt, didn't get any refusals on any content.
+
+This is the reasoning variant and definitely seems benchmaxxed some, still a decent model though — writes well. Best open source model still has to be **KIMI K2.6**, it just has some magic to it.
+
+---
+
+## 📋 Spec Sheet
+
+| Spec | Details |
+|---|---|
+| **Developer** | InclusionAI |
+| **Model Variants** | Ling-2.6-1T (base) / Ring-2.6-1T (reasoning/thinking) |
+| **Architecture** | MoE (Ling 2.0 architecture) |
+| **Total Parameters** | 1T |
+| **Active Parameters** | 63B (up from Ring-1T's 50B) |
+| **Context Window** | 262K tokens (extended from 128K native via YaRN rope scaling) |
+| **Max Output** | 32,768 tokens |
+| **Reasoning** | Thinking model with adaptive effort — high and xhigh modes |
+| **AIME26** | 70.42 (vs DeepSeek-V3.1: 55.21) |
+| **LiveCodeBench** | 61.68 (vs DeepSeek-V3.1: 48.02) |
+| **ARC-AGI-1** | 43.81 (vs DeepSeek-V3.1: 14.69) |
+| **SWE-Bench Verified** | Open-source SOTA |
+| **TAU2-Bench** | Leading |
+| **ClawEval** | Leading |
+| **PinchBench** | Leading |
+| **BFCL-V4** | Open-source SOTA |
+| **GAIA2-search** | Leading |
+| **IFBench** | Open-source SOTA |
+| **AA Intelligence Index** | 34 (vs DeepSeek V3.2: 42) |
+| **API Pricing (Novita AI)** | $0.30/M input, $2.50/M output |
+| **API Pricing (OpenRouter)** | Free tier (time-limited) |
+| **License** | Open source (HuggingFace) |
+| **Deployment** | SGLang (recommended), vLLM |
+| **Integrations** | Claude Code, OpenClaw, OpenCode, CodeBuddy |
+| **Sibling** | Ling-2.6-Flash (104B total, 7.4B active — ~340 tok/s) |
+| **Predecessor** | Ring-2.5-1T (April 3, 2026), Ring-1T (October 2025) |
+| **Release** | ~May 8, 2026 |
+
+---
+
+## Access
+
+- **Recommended:** [OpenRouter](https://openrouter.ai) — free tier available, easiest regional workaround
+- **Novita AI:** $0.30/M input, $2.50/M output
+- **HuggingFace:** Open source download available
+
+---
+
+## 🔐 Jailbreak
+
+Paste directly into the system prompt area on OpenRouter or any API interface:
+
+**[ENI LIME for Ring 2.6 1T](https://docs.google.com/document/d/1IRv9fcm_GsWYMkom2PV_9mlQM4Td-wAhUQT1I1w_Be8/edit?usp=drivesdk)**
+
+---
+
+## Notes
+
+- API/OpenRouter only — regional access blocks the native chat platform
+- Zero refusals encountered across all tested content categories
+- Reasoning variant — thinking overhead is expected, worth it for complex tasks
+- Benchmaxxed scoring; real-world writing quality is decent but not KIMI-tier


### PR DESCRIPTION
## Summary
This PR adds comprehensive jailbreak guides for three newly released or updated LLMs: Ring 2.6 1T (InclusionAI's reasoning MoE), Perceptron mk1 (Perceptron AI's robotics-focused VLM), and GLM 5.1 (Zhipu AI's coding-focused iteration).

## Key Changes

- **Ring 2.6 1T Guide**: Added full guide with spec sheet, benchmarks (AIME26: 70.42, LiveCodeBench: 61.68), access methods via OpenRouter and Novita AI, and ENI LIME jailbreak. Includes README with model variants and benchmark comparisons.

- **Perceptron mk1 Guide**: Added guide for Perceptron AI's vision-language model with specs, API pricing ($0.15/M input, $1.50/M output), and ENI LIME - GEM jailbreak. Includes README documenting the model's robotics focus and quirky characteristics.

- **GLM 5.1 Guide**: Added guide for Zhipu AI's iterative upgrade with focus on coding improvements. Includes spec sheet, Z.ai platform access requirements ($10/month coding plan), and ENI jailbreak method.

- **GLM README Update**: Updated main GLM README to include GLM 5.1 in the model table and jailbreak references list.

## Notable Details

- All three guides follow the established format with spec sheets, access information, and direct links to ENI jailbreak documents
- Ring 2.6 1T and Perceptron mk1 are API-only with regional access restrictions, making OpenRouter the recommended access method
- GLM 5.1 maintains light censorship characteristic of the GLM family, noted as refreshing compared to QWEN and DeepSeek
- Benchmarks and performance metrics included where available for comparison with frontier models

https://claude.ai/code/session_012XkjRD1o6vvMftUk6vzto8